### PR TITLE
Make reorder to work with unused factor levels

### DIFF
--- a/R/reorder.R
+++ b/R/reorder.R
@@ -36,7 +36,7 @@ fct_reorder <- function(f, x, fun = median, ...) {
   f <- check_factor(f)
   stopifnot(length(f) == length(x))
 
-  summary <- tapply(x, as.factor(f), fun, ...)
+  summary <- tapply(x, f, fun, ...)
   if (!is.numeric(summary)) {
     stop("`fun` must return a single number per group", call. = FALSE)
   }
@@ -50,7 +50,7 @@ fct_reorder2 <- function(f, x, y, fun = last2, ...) {
   f <- check_factor(f)
   stopifnot(length(f) == length(x), length(x) == length(y))
 
-  summary <- tapply(seq_along(x), as.factor(f), function(i) fun(x[i], y[i], ...))
+  summary <- tapply(seq_along(x), f, function(i) fun(x[i], y[i], ...))
   if (!is.numeric(summary)) {
     stop("`fun` must return a single number per group", call. = FALSE)
   }

--- a/R/reorder.R
+++ b/R/reorder.R
@@ -36,7 +36,7 @@ fct_reorder <- function(f, x, fun = median, ...) {
   f <- check_factor(f)
   stopifnot(length(f) == length(x))
 
-  summary <- tapply(x, factor(f), fun, ...)
+  summary <- tapply(x, as.factor(f), fun, ...)
   if (!is.numeric(summary)) {
     stop("`fun` must return a single number per group", call. = FALSE)
   }


### PR DESCRIPTION
fixes #10 

This was fixed for `reorder2` in 854c7ea6e6452ffd291e9db1056f1b2574593738 but not for `reorder`.

I don't know whether  `as.factor()` is necessary at all, as `check_factor(f)` will ensure that f is a factor, but this is in line with `reorder2`.