### PR TITLE
Remove levels in fct_recode using NULL

### DIFF
--- a/R/recode.R
+++ b/R/recode.R
@@ -4,7 +4,7 @@
 #' @param ... A sequence of named character vectors where the
 #'   name gives the new level, and the value gives the old level.
 #'   Levels not otherwise mentioned will be left as is. Levels can
-#'   be removed by naming them NULL.
+#'   be removed by naming them \code{NULL}.
 #' @export
 #' @examples
 #' x <- factor(c("apple", "bear", "banana", "dear"))
@@ -16,7 +16,6 @@
 #' # If you name the level NULL it will be removed
 #' fct_recode(x, NULL = "apple", fruit = "banana")
 fct_recode <- function(f, ...) {
-
   f <- check_factor(f)
 
   new_levels <- c(...)
@@ -44,7 +43,5 @@ fct_recode <- function(f, ...) {
 
   old_levels[idx] <- names(new_levels)
 
-  f <- lvls_revalue(f, old_levels)
-
-  f
+  lvls_revalue(f, old_levels)
 }

--- a/R/recode.R
+++ b/R/recode.R
@@ -3,7 +3,8 @@
 #' @param f A factor.
 #' @param ... A sequence of named character vectors where the
 #'   name gives the new level, and the value gives the old level.
-#'   Levels not otherwise mentioned will be left as is.
+#'   Levels not otherwise mentioned will be left as is. Levels can
+#'   be removed by naming them NULL.
 #' @export
 #' @examples
 #' x <- factor(c("apple", "bear", "banana", "dear"))
@@ -11,11 +12,22 @@
 #'
 #' # If you make a mistake you'll get a warning
 #' fct_recode(x, fruit = "apple", fruit = "bananana")
+#'
+#' # If you name the level NULL it will be removed
+#' fct_recode(x, NULL = "apple", fruit = "banana")
 fct_recode <- function(f, ...) {
+
   f <- check_factor(f)
 
   new_levels <- c(...)
   stopifnot(is.character(new_levels))
+
+  # Remove any named NULL and finish if all NULLs
+  nulls <- names(new_levels) == "NULL"
+  if (any(nulls)) {
+    f <- factor(f, levels = setdiff(levels(f), new_levels[nulls]))
+    new_levels <- new_levels[!nulls]
+  }
 
   # Match old levels with new levels
   old_levels <- levels(f)
@@ -32,5 +44,7 @@ fct_recode <- function(f, ...) {
 
   old_levels[idx] <- names(new_levels)
 
-  lvls_revalue(f, old_levels)
+  f <- lvls_revalue(f, old_levels)
+
+  f
 }

--- a/man/fct_recode.Rd
+++ b/man/fct_recode.Rd
@@ -11,7 +11,8 @@ fct_recode(f, ...)
 
 \item{...}{A sequence of named character vectors where the
 name gives the new level, and the value gives the old level.
-Levels not otherwise mentioned will be left as is.}
+Levels not otherwise mentioned will be left as is. Levels can
+be removed by naming them NULL.}
 }
 \description{
 Change the levels of a factor
@@ -22,5 +23,8 @@ fct_recode(x, fruit = "apple", fruit = "banana")
 
 # If you make a mistake you'll get a warning
 fct_recode(x, fruit = "apple", fruit = "bananana")
+
+# If you name the level NULL it will be removed
+fct_recode(x, NULL = "apple", fruit = "banana")
 }
 

--- a/man/fct_recode.Rd
+++ b/man/fct_recode.Rd
@@ -12,7 +12,7 @@ fct_recode(f, ...)
 \item{...}{A sequence of named character vectors where the
 name gives the new level, and the value gives the old level.
 Levels not otherwise mentioned will be left as is. Levels can
-be removed by naming them NULL.}
+be removed by naming them \code{NULL}.}
 }
 \description{
 Change the levels of a factor

--- a/tests/testthat/test-fct_recode.R
+++ b/tests/testthat/test-fct_recode.R
@@ -13,3 +13,17 @@ test_that("can collapse levels", {
 
   expect_equal(fct_recode(f1, a = "a1", a = "a2", b = "b1", b = "b2"), f2)
 })
+
+test_that("can recode multiple levels to NA", {
+  f1 <- factor(c("a1", "empty", "a2", "b", "missing"))
+  f2 <- factor(c("a", NA, "a", "b", NA))
+
+  expect_equal(fct_recode(f1, NULL = "missing", NULL = "empty", a = "a1", a = "a2"), f2)
+})
+
+test_that("can just remove levels", {
+  f1 <- factor(c("a", "missing"))
+  f2 <- factor(c("a", NA))
+
+  expect_equal(fct_recode(f1, NULL = "missing"), f2)
+})


### PR DESCRIPTION
This addresses issue #20. There is risk that someone will want to have levels named "NULL", but that seems like an acceptable edge case to allow users to handle themselves.