### PR TITLE
add an option to relevel to the end

### DIFF
--- a/R/relevel.R
+++ b/R/relevel.R
@@ -1,35 +1,43 @@
 #' Change the order of levels in a factor
 #'
 #' This is a generalisaton of \code{\link[stats]{relevel}} that allows you to
-#' move any number of levels to the front.
+#' move any number of levels to appear first or last in the levels list.
 #'
 #' @param f A factor.
 #' @param ... Character vector of levels. Any levels not mentioned will be
 #'   left in existing order, after the explicitly mentioned levels.
+#' @param .last A logical indicating whether the target level(s) should be placed last. Defaults to FALSE.
 #' @export
 #' @examples
-#' f <- factor(c("a", "b", "c"))
+#' f <- factor(c(letters[1:5]))
 #' fct_relevel(f)
 #' fct_relevel(f, "c")
 #' fct_relevel(f, "b", "a")
+#' fct_relevel(f, "b", "a", .last = TRUE)
 #'
 #' # You'll get a warning if the levels don't exist
 #' fct_relevel(f, "d")
-fct_relevel <- function(f, ...) {
+fct_relevel <- function(f, ..., .last = FALSE) {
   f <- check_factor(f)
 
-  first_levels <- c(..., character())
-  stopifnot(is.character(first_levels))
+  target_levels <- c(..., character())
+  stopifnot(is.character(target_levels))
 
   old_levels <- levels(f)
 
-  unknown <- setdiff(first_levels, old_levels)
+  unknown <- setdiff(target_levels, old_levels)
   if (length(unknown) > 0) {
     warning("Unknown levels in `f`: ", paste(unknown, collapse = ", "), call. = FALSE)
-    first_levels <- intersect(first_levels, old_levels)
+    target_levels <- intersect(target_levels, old_levels)
   }
 
-  new_levels <- c(first_levels, setdiff(old_levels, first_levels))
+  if(.last){
+    # place target levels at the end
+    new_levels <- c(setdiff(old_levels, target_levels), target_levels)
+  } else {
+    # place the target levels at the start
+    new_levels <- c(target_levels, setdiff(old_levels, target_levels))
+  }
 
   lvls_reorder(f, match(new_levels, old_levels))
 }

--- a/man/fct_relevel.Rd
+++ b/man/fct_relevel.Rd
@@ -4,23 +4,26 @@
 \alias{fct_relevel}
 \title{Change the order of levels in a factor}
 \usage{
-fct_relevel(f, ...)
+fct_relevel(f, ..., .last = FALSE)
 }
 \arguments{
 \item{f}{A factor.}
 
 \item{...}{Character vector of levels. Any levels not mentioned will be
 left in existing order, after the explicitly mentioned levels.}
+
+\item{.last}{A logical indicating whether the target level(s) should be placed last. Defaults to FALSE.}
 }
 \description{
 This is a generalisaton of \code{\link[stats]{relevel}} that allows you to
-move any number of levels to the front.
+move any number of levels to appear first or last in the levels list.
 }
 \examples{
-f <- factor(c("a", "b", "c"))
+f <- factor(c(letters[1:5]))
 fct_relevel(f)
 fct_relevel(f, "c")
 fct_relevel(f, "b", "a")
+fct_relevel(f, "b", "a", .last = TRUE)
 
 # You'll get a warning if the levels don't exist
 fct_relevel(f, "d")

--- a/tests/testthat/test-fct_relevel.R
+++ b/tests/testthat/test-fct_relevel.R
@@ -13,3 +13,11 @@ test_that("moves supplied levels to front", {
   f2 <- fct_relevel(f1, "c", "b")
   expect_equal(levels(f2), c("c", "b", "a", "d"))
 })
+
+
+test_that("moves supplied levels to the end", {
+  f1 <- factor(c("a", "b", "c", "d"))
+
+  f2 <- fct_relevel(f1, "c", "b", .last = TRUE)
+  expect_equal(levels(f2), c("a", "d", "c", "b"))
+})


### PR DESCRIPTION
This pull request adds the ability to relevel "at the end" by specifying the parameter `.last = TRUE`.

The use case for this is that many nuisance factor levels such as "other", "don't know", and "refuse to answer" can be placed at the end of a factor list. This can be useful for packages like `ggplot2` where factor levels impact the ordering of aesthetics.