### PR TITLE
Add `desc` argument to `fct_infreq()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # forcats (development version)
 
+* `fct_infreq()` gains a `desc` argument to allow ordering in ascending
+  frequency (#365).
+
 # forcats 1.0.1
 
 * `fct_cross()` now varies the levels in the last factor fastest (@Adam-AKong, #373).

--- a/R/reorder.R
+++ b/R/reorder.R
@@ -175,17 +175,21 @@ terminal <- function(x, y, desc) {
 #'
 #' This family of functions changes only the order of the levels.
 #' * `fct_inorder()`: by the order in which they first appear.
-#' * `fct_infreq()`: by number of observations with each level (largest first)
+#' * `fct_infreq()`: by number of observations with each level (largest first
+#'   by default; set `desc = FALSE` for smallest first)
 #' * `fct_inseq()`: by numeric value of level.
 #'
 #' @inheritParams lvls_reorder
 #' @param f A factor
+#' @param desc Order in descending frequency? Defaults to `TRUE`;
+#'   set `FALSE` for ascending.
 #' @export
 #' @examples
 #' f <- factor(c("b", "b", "a", "c", "c", "c"))
 #' f
 #' fct_inorder(f)
 #' fct_infreq(f)
+#' fct_infreq(f, desc = FALSE)
 #'
 #' f <- factor(1:3, levels = c("3", "2", "1"))
 #' f
@@ -202,12 +206,13 @@ fct_inorder <- function(f, ordered = NA) {
 #' @export
 #' @rdname fct_inorder
 #' @inheritParams fct_lump
-fct_infreq <- function(f, w = NULL, ordered = NA) {
+fct_infreq <- function(f, w = NULL, ordered = NA, desc = TRUE) {
   f <- check_factor(f)
   w <- compute_weights(f, w)
   check_bool(ordered, allow_na = TRUE)
+  check_bool(desc)
 
-  lvls_reorder(f, order(w, decreasing = TRUE), ordered = ordered)
+  lvls_reorder(f, order(w, decreasing = desc), ordered = ordered)
 }
 
 #' @export

--- a/man/fct_inorder.Rd
+++ b/man/fct_inorder.Rd
@@ -8,7 +8,7 @@
 \usage{
 fct_inorder(f, ordered = NA)
 
-fct_infreq(f, w = NULL, ordered = NA)
+fct_infreq(f, w = NULL, ordered = NA, desc = TRUE)
 
 fct_inseq(f, ordered = NA)
 }
@@ -20,12 +20,16 @@ output factor. \code{NA} preserves the existing status of the factor.}
 
 \item{w}{An optional numeric vector giving weights for frequency of
 each value (not level) in \code{f}.}
+
+\item{desc}{Order in descending frequency? Defaults to \code{TRUE};
+set \code{FALSE} for ascending.}
 }
 \description{
 This family of functions changes only the order of the levels.
 \itemize{
 \item \code{fct_inorder()}: by the order in which they first appear.
-\item \code{fct_infreq()}: by number of observations with each level (largest first)
+\item \code{fct_infreq()}: by number of observations with each level (largest first
+by default; set \code{desc = FALSE} for smallest first)
 \item \code{fct_inseq()}: by numeric value of level.
 }
 }
@@ -34,6 +38,7 @@ f <- factor(c("b", "b", "a", "c", "c", "c"))
 f
 fct_inorder(f)
 fct_infreq(f)
+fct_infreq(f, desc = FALSE)
 
 f <- factor(1:3, levels = c("3", "2", "1"))
 f

--- a/tests/testthat/_snaps/reorder.md
+++ b/tests/testthat/_snaps/reorder.md
@@ -79,6 +79,11 @@
     Condition
       Error in `fct_infreq()`:
       ! `ordered` must be `TRUE`, `FALSE`, or `NA`, not the number 1.
+    Code
+      fct_infreq(f, desc = 1)
+    Condition
+      Error in `fct_infreq()`:
+      ! `desc` must be `TRUE` or `FALSE`, not the number 1.
 
 # fct_inorder() validates its inputs
 

--- a/tests/testthat/test-reorder.R
+++ b/tests/testthat/test-reorder.R
@@ -166,7 +166,14 @@ test_that("fct_infreq() validates its inputs", {
     fct_infreq(f, 1:4)
     fct_infreq(f, "x")
     fct_infreq(f, ordered = 1)
+    fct_infreq(f, desc = 1)
   })
+})
+
+test_that("fct_infreq() can order in ascending frequency", {
+  f <- factor(c("b", "b", "a", "c", "c", "c"))
+  expect_equal(levels(fct_infreq(f)), c("c", "b", "a"))
+  expect_equal(levels(fct_infreq(f, desc = FALSE)), c("a", "b", "c"))
 })
 
 test_that("fct_infreq() preserves empty levels", {


### PR DESCRIPTION
Closes #365.

Adds a `desc` argument so you can order levels by ascending frequency with `desc = FALSE`. Defaults to `TRUE` so nothing changes for existing code.

```r
f <- factor(c("b", "b", "a", "c", "c", "c"))
fct_infreq(f)              # c, b, a (descending, same as before)
fct_infreq(f, desc = FALSE) # a, b, c (ascending)
```

Includes docs, an example, and tests. `R CMD check` passes with 0 errors, 0 warnings, 0 notes.