### PR TITLE
Clarify fct_reorder2 ordering documentation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # forcats (development version)
 
+* The `fct_reorder2()` documentation now notes that `.desc` controls the sort
+  direction (#352).
+
 # forcats 1.0.1
 
 * `fct_cross()` now varies the levels in the last factor fastest (@Adam-AKong, #373).

--- a/R/reorder.R
+++ b/R/reorder.R
@@ -6,10 +6,10 @@
 #' `last2()` finds the last value of `y` when sorted by `x`; `first2()` finds the first value.
 #'
 #' @param .f A factor (or character vector).
-#' @param .x,.y The levels of `f` are reordered so that the values
-#'    of `.fun(.x)` (for `fct_reorder()`) and `fun(.x, .y)` (for `fct_reorder2()`)
-#'    are in ascending order.
-#' @param .fun n summary function. It should take one vector for
+#' @param .x,.y The levels of `f` are reordered according to the values
+#'    of `.fun(.x)` (for `fct_reorder()`) and `.fun(.x, .y)` (for
+#'    `fct_reorder2()`). The sort direction is controlled by `.desc`.
+#' @param .fun A summary function. It should take one vector for
 #'   `fct_reorder`, and two vectors for `fct_reorder2`, and return a single
 #'   value.
 #' @param .na_rm Should `fct_reorder()` remove missing values?

--- a/man/fct_reorder.Rd
+++ b/man/fct_reorder.Rd
@@ -35,11 +35,11 @@ first2(.x, .y)
 \arguments{
 \item{.f}{A factor (or character vector).}
 
-\item{.x, .y}{The levels of \code{f} are reordered so that the values
-of \code{.fun(.x)} (for \code{fct_reorder()}) and \code{fun(.x, .y)} (for \code{fct_reorder2()})
-are in ascending order.}
+\item{.x, .y}{The levels of \code{f} are reordered according to the values
+of \code{.fun(.x)} (for \code{fct_reorder()}) and \code{.fun(.x, .y)} (for
+\code{fct_reorder2()}). The sort direction is controlled by \code{.desc}.}
 
-\item{.fun}{n summary function. It should take one vector for
+\item{.fun}{A summary function. It should take one vector for
 \code{fct_reorder}, and two vectors for \code{fct_reorder2}, and return a single
 value.}
 


### PR DESCRIPTION
Fixes #352.

This updates the `fct_reorder2()` documentation so it no longer says that the summary values are always put in ascending order. The revised wording notes that `.desc` controls the sort direction, and also fixes the `.fun(.x, .y)` typo in the same argument text.

Checks:
- Verified the issue reprex gives levels `b`, `a` by default with `.desc = TRUE`
- `Rscript -e 'tools::checkRd("man/fct_reorder.Rd")'`\n- `git diff --check`\n- `R CMD build --no-build-vignettes .`\n- `_R_CHECK_FORCE_SUGGESTS_=false R CMD check --no-manual --ignore-vignettes --no-build-vignettes --no-tests forcats_1.0.1.9000.tar.gz`