### PR TITLE
fix: fct_reorder() error with character .f and NA in .x (#359)

### DIFF
--- a/R/reorder.R
+++ b/R/reorder.R
@@ -81,6 +81,7 @@ fct_reorder <- function(
     if (isTRUE(.na_rm)) {
       .x <- .x[!miss]
       .f <- .f[!miss]
+      f <- check_factor(.f)
     }
   }
 

--- a/tests/testthat/test-reorder.R
+++ b/tests/testthat/test-reorder.R
@@ -24,6 +24,21 @@ test_that("automatically removes missing values with a warning", {
   expect_equal(levels(f3), c("b", "a", "c"))
 })
 
+test_that("fct_reorder() handles NA in .x with character .f (#359)", {
+  f <- c("a", "b", "c")
+  x <- c(1, 2, NA)
+
+  expect_warning(f1 <- fct_reorder(f, x), "removing")
+  expect_equal(levels(f1), c("a", "b"))
+
+  f2 <- fct_reorder(f, x, .na_rm = TRUE)
+  expect_equal(levels(f2), c("a", "b"))
+
+  # Factor input preserves all levels (even unused ones after NA removal)
+  f3 <- fct_reorder(as_factor(f), x, .na_rm = TRUE)
+  expect_equal(levels(f3), c("a", "b", "c"))
+})
+
 test_that("can control the placement of empty levels", {
   f1 <- fct(c("a", "b", "c"), letters[1:4])
   x <- c(1, 2, 3)


### PR DESCRIPTION
## Problem

`fct_reorder()` errors when `.f` is a character vector and `.x` contains `NA` values (with `.na_rm = TRUE`):

```r
f <- c("a", "b", "c")
x <- c(1, 2, NA)
fct_reorder(f, x)
#> Error in `lvls_reorder()`: `idx` must contain one integer for each level of `f`
```

The same call works when `.f` is a factor (`as_factor(f)`). This inconsistency is reported in #359.

## Root Cause

In `fct_reorder()`, after removing `NA` values:
- `.f` (the original input) is subsetted correctly
- `f` (the factor created by `check_factor()`) is NOT subsetted

When `.f` is a character vector, `tapply(.x, .f, ...)` produces a summary with entries only for the remaining unique values. But `lvls_reorder(f, ...)` expects one index per level in the original (unsubsetted) factor — causing the error.

When `.f` is already a factor, subsetting preserves all levels, so `tapply` includes all levels (using the `.default` for empty groups), and the lengths match.

## Fix

After subsetting `.f` to remove NAs, reconstruct `f` from the subsetted `.f`:

```r
f <- check_factor(.f)
```

This ensures `f` has levels matching only the values present after NA removal.

**One line changed in `R/reorder.R`.**

## Tests

Added one test case covering:
1. Character `.f` with `NA` in `.x` (default `.na_rm = NULL` → warns and works)
2. Character `.f` with `NA` in `.x` (`.na_rm = TRUE` → silent)
3. Factor `.f` preserves all levels (including unused after NA removal)

All 38 reorder tests pass (9 skipped as CRAN-only snapshot tests).

```
[ FAIL 0 | WARN 0 | SKIP 9 | PASS 38 ]
```