### PR TITLE
fix: preserve label attribute when converting character to factor (#346)

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -13,7 +13,12 @@ NULL
 
 check_factor <- function(x, arg = caller_arg(x), call = caller_env()) {
   if (is.character(x)) {
-    factor(x)
+    label <- attr(x, "label", exact = TRUE)
+    out <- factor(x)
+    if (!is.null(label)) {
+      attr(out, "label") <- label
+    }
+    out
   } else if (is.factor(x)) {
     x
   } else {

--- a/tests/testthat/test-recode.R
+++ b/tests/testthat/test-recode.R
@@ -29,6 +29,15 @@ test_that("can just remove levels", {
   expect_equal(fct_recode(f1, NULL = "missing"), f2)
 })
 
+test_that("fct_recode preserves label attribute on character input", {
+  x <- c("a", "b", "c")
+  attr(x, "label") <- "my variable"
+
+  result <- fct_recode(x, d = "c")
+  expect_equal(attr(result, "label"), "my variable")
+  expect_equal(levels(result), c("a", "b", "d"))
+})
+
 
 # check_recode_levels -----------------------------------------------------
 


### PR DESCRIPTION
## Summary

This PR fixes #346 by preserving the `label` attribute when converting a character vector to a factor in `check_factor()`.

## Problem

When passing a character vector with a `label` attribute (common in haven-labelled data) to `fct_recode()` or other forcats functions, the `label` attribute is silently dropped.

```r
library(haven)
library(forcats)
x <- read_dta("file.dta")$species  # has label="Species"
attr(x, "label")  # "Species"
attr(fct_recode(x, seto = "setosa"), "label")  # NULL (before fix)
```

## Solution

Modified `check_factor()` in `R/utils.R` to preserve the `label` attribute when converting from character to factor. This fix applies to all forcats functions that use `check_factor()`, including `fct_recode()`, `fct_reorder()`, `fct_collapse()`, `fct_lump()`, etc.

## Changes

- `R/utils.R`: Added 4 lines to preserve `label` attribute in `check_factor()`
- `tests/testthat/test-recode.R`: Added test verifying `label` attribute preservation

## Validation

- R CMD check: Status OK
- All existing tests pass
- New test verifies the fix

## Related

Fixes #346