### PR TITLE
fix: error early when .x is non-numeric and default .fun is used (#387)

### DIFF
--- a/R/reorder.R
+++ b/R/reorder.R
@@ -62,6 +62,16 @@ fct_reorder <- function(
 ) {
   f <- check_factor(.f)
   stopifnot(length(f) == length(.x))
+
+  if (missing(.fun) && !is.numeric(.x)) {
+    cli::cli_abort(
+      c(
+        "{.arg .x} must be a numeric vector when using the default {.arg .fun}.",
+        i = "Either supply a numeric {.arg .x} or provide a custom {.arg .fun}."
+      )
+    )
+  }
+
   .fun <- as_function(.fun)
   check_dots_used()
   check_bool(.na_rm, allow_null = TRUE)

--- a/tests/testthat/_snaps/reorder.md
+++ b/tests/testthat/_snaps/reorder.md
@@ -39,6 +39,24 @@
       Error in `fct_reorder()`:
       ! `.desc` must be `TRUE` or `FALSE`, not the number 1.
 
+# fct_reorder() errors with character .x and default .fun (#387)
+
+    Code
+      fct_reorder(f, x)
+    Condition
+      Error in `fct_reorder()`:
+      ! `.x` must be a numeric vector when using the default `.fun`.
+      i Either supply a numeric `.x` or provide a custom `.fun`.
+
+# fct_reorder() errors with factor .x and default .fun (#387)
+
+    Code
+      fct_reorder(f, x)
+    Condition
+      Error in `fct_reorder()`:
+      ! `.x` must be a numeric vector when using the default `.fun`.
+      i Either supply a numeric `.x` or provide a custom `.fun`.
+
 # fct_reorder2() automatically removes missing values with a warning
 
     Code

--- a/tests/testthat/test-reorder.R
+++ b/tests/testthat/test-reorder.R
@@ -55,6 +55,33 @@ test_that("fct_reorder() validates its inputs", {
   })
 })
 
+test_that("fct_reorder() errors with character .x and default .fun (#387)", {
+  f <- c("a", "b", "b")
+  x <- c("z", "x", "y")
+
+  expect_snapshot(error = TRUE, {
+    fct_reorder(f, x)
+  })
+})
+
+test_that("fct_reorder() errors with factor .x and default .fun (#387)", {
+  f <- c("a", "b", "b")
+  x <- factor(c("z", "x", "y"))
+
+  expect_snapshot(error = TRUE, {
+    fct_reorder(f, x)
+  })
+})
+
+test_that("fct_reorder() works with character .x and custom .fun (#387)", {
+  f <- c("a", "b", "b")
+  x <- c("z", "x", "y")
+
+  # Should work with a custom function that handles character vectors
+  result <- fct_reorder(f, x, .fun = function(x) x[1])
+  expect_equal(levels(result), c("b", "a"))
+})
+
 # fct_reorder2 ------------------------------------------------------------
 
 test_that("can reorder by 2d summary", {


### PR DESCRIPTION
## Problem

`fct_reorder()` produces incorrect results or confusing errors when `.x` is a character vector or factor and the default `.fun = median` is used:

```r
f = c("a", "b", "b")
x = c("z", "x", "y")

# Character .x: silently returns NA with warning, wrong ordering
forcats::fct_reorder(f, x)
#> Warning in mean.default(sort(x, partial = half + 0L:1L)[half + 0L:1L]):
#> argument is not numeric or logical: returning NA
#> [1] a b b
#> Levels: a b  # Wrong! Should be b a

# Factor .x: confusing error about numeric data
x = factor(c("z", "x", "y"))
forcats::fct_reorder(f, x)
#> Error in median.default(x, ...): need numeric data
```

## Solution

Added input validation that errors early with a clear message when `.x` is not numeric and the default `.fun = median` is used:

```r
fct_reorder(f, x)
#> Error in `fct_reorder()`:
#> ! `.x` must be a numeric vector when using the default `.fun`.
#> i Either supply a numeric `.x` or provide a custom `.fun`.
```

Users can still use `fct_reorder()` with character/factor `.x` by providing a custom `.fun`:

```r
fct_reorder(f, x, .fun = function(x) x[1])
#> [1] a b b
#> Levels: b a
```

## Changes

- `R/reorder.R`: Added validation for `.x` type when using default `.fun`
- `tests/testthat/test-reorder.R`: Added 3 tests for character, factor, and custom `.fun` cases
- `tests/testthat/_snaps/reorder.md`: Updated snapshots with new error messages

## Validation

- All 223 tests pass
- R CMD check passes with Status: OK
- No duplicate PRs found for issue #387
