### PR TITLE
test: add edge-case tests for fct_rev()

### DIFF
--- a/tests/testthat/test-rev.R
+++ b/tests/testthat/test-rev.R
@@ -4,3 +4,42 @@ test_that("reverses levels", {
 
   expect_equal(levels(f2), c("b", "a"))
 })
+
+test_that("preserves NA values in data", {
+  f1 <- factor(c("a", "b", NA, "c"))
+  f2 <- fct_rev(f1)
+
+  expect_equal(levels(f2), c("c", "b", "a"))
+  expect_equal(which(is.na(f2)), 3L)
+})
+
+test_that("empty factor returns empty factor", {
+  f1 <- factor(character())
+  f2 <- fct_rev(f1)
+
+  expect_equal(levels(f2), character())
+  expect_length(f2, 0)
+})
+
+test_that("single level is unchanged", {
+  f1 <- factor(c("a", "a"))
+  f2 <- fct_rev(f1)
+
+  expect_equal(levels(f2), "a")
+})
+
+test_that("preserves unused levels", {
+  f1 <- factor("a", levels = c("a", "b", "c"))
+  f2 <- fct_rev(f1)
+
+  expect_equal(levels(f2), c("c", "b", "a"))
+  expect_equal(as.character(f2), "a")
+})
+
+test_that("preserves ordered class", {
+  f1 <- ordered(c("a", "b", "c"), levels = c("a", "b", "c"))
+  f2 <- fct_rev(f1)
+
+  expect_s3_class(f2, "ordered")
+  expect_equal(levels(f2), c("c", "b", "a"))
+})


### PR DESCRIPTION
## Summary

Adds edge-case test coverage for `fct_rev()`, which previously had only 1 test.

## Tests Added

1. **NA values**: Verifies NA positions are preserved after level reversal
2. **Empty factor**: Verifies empty input returns empty factor with no levels
3. **Single level**: Verifies single-level factor is unchanged
4. **Unused levels**: Verifies unused levels are reversed correctly
5. **Ordered class**: Verifies ordered factor class is preserved

## Tests Run

```
[ FAIL 0 | WARN 0 | SKIP 0 | PASS 10 ]
```

All 10 tests in `test-rev.R` pass (1 existing + 5 new). Full suite: 229 PASS, 0 FAIL.